### PR TITLE
Back: Entities table / Front: more robust functionality

### DIFF
--- a/app/controllers/api/entities_controller.rb
+++ b/app/controllers/api/entities_controller.rb
@@ -1,0 +1,16 @@
+class Api::EntitiesController < ApplicationController
+
+  def index
+    render json: Entity.all
+  end
+
+  def show
+    render json: Entity.find_by!(entity_params)
+  end
+
+  private
+
+  def entity_params
+    params.permit(:id, :type, :name, :description)
+  end
+end

--- a/app/controllers/api/entity_items_controller.rb
+++ b/app/controllers/api/entity_items_controller.rb
@@ -1,0 +1,15 @@
+class Api::EntityItemsController < ApplicationController
+  def index
+    render json: EntityItem.all
+  end
+
+  def show
+    render json: EntityItem.find_by!(entity_item_params)
+  end
+
+  private
+
+  def entity_item_params
+    params.permit(:id, :entity_id, :item_id)
+  end)
+end

--- a/app/controllers/api/game_items_controller.rb
+++ b/app/controllers/api/game_items_controller.rb
@@ -4,18 +4,18 @@ class Api::GameItemsController < ApplicationController
     end
 
     def create
-        pos = @current_user.gamesaves.find_by!(gamesave_id: pos_params[:gamesave_id]).game_items.create!(pos_params)
-        render json: pos, status: 201
+        item = @current_user.gamesaves.find_by!(gamesave_id: item_params[:gamesave_id]).game_items.create!(item_params)
+        render json: item, status: 201
     end
 
     def destroy
-        @current_user.game_items.find(pos_params[:id]).destroy!
+        @current_user.game_items.find(item_params[:id]).destroy!
         head 204
     end
 
     private
 
-    def pos_params
+    def item_params
         params.permit(:id, :gamesave_id, :item_id)
     end
 end

--- a/app/controllers/api/world_entities_controller.rb
+++ b/app/controllers/api/world_entities_controller.rb
@@ -1,0 +1,15 @@
+class Api::WorldEntitiesController < ApplicationController
+  def index
+    render json: WorldEntity.all
+  end
+
+  def show
+    render json: WorldEntity.find_by!(world_entities_params)
+  end
+
+  private
+
+  def world_entities_params
+    params.permmit(:id, :worldmap_id, :entity_id)
+  end
+end

--- a/app/controllers/api/worldmaps_controller.rb
+++ b/app/controllers/api/worldmaps_controller.rb
@@ -1,11 +1,11 @@
 class Api::WorldmapsController < ApplicationController
 
     def index
-        render json: Worldmap.all
+        render json: Worldmap.all, include: "entities.items"
     end
 
     def show
-        render json: Worldmap.find_by!(worldmap_search_params)
+        render json: Worldmap.find_by!(worldmap_search_params), include: "entities.items"
     end
 
     private

--- a/app/models/entity.rb
+++ b/app/models/entity.rb
@@ -1,0 +1,6 @@
+class Entity < ApplicationRecord
+  validates :group, :name, :description, presence: true
+  
+  has_many :entity_items
+  has_many :items, through: :entity_items
+end

--- a/app/models/entity_item.rb
+++ b/app/models/entity_item.rb
@@ -1,0 +1,4 @@
+class EntityItem < ApplicationRecord
+  belongs_to :entity
+  belongs_to :item
+end

--- a/app/models/gamesave.rb
+++ b/app/models/gamesave.rb
@@ -1,4 +1,6 @@
 class Gamesave < ApplicationRecord
+  # validates :x, :y, :user_id, presence: true
+  
   belongs_to :user
 
   has_many :game_items

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,6 @@
 class Item < ApplicationRecord
+    validates :name, :description, presence: true
+    
     has_many :world_items
     has_many :worldmaps, through: :world_items
     

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,6 @@
 class User < ApplicationRecord
-    validates :username, presence: true, uniqueness: { case_sensitive: false }
+    validates :username, :password_digest, presence: true, uniqueness: { case_sensitive: false }
     has_secure_password
 
     has_many :gamesaves
-    # has_many :drops, through: :gamesaves
 end

--- a/app/models/world_entity.rb
+++ b/app/models/world_entity.rb
@@ -1,0 +1,4 @@
+class WorldEntity < ApplicationRecord
+  belongs_to :worldmap
+  belongs_to :entity
+end

--- a/app/models/worldmap.rb
+++ b/app/models/worldmap.rb
@@ -1,7 +1,12 @@
 class Worldmap < ApplicationRecord
+  validates :x, :y, :name, :description, presence: true
   validates :x, uniqueness: { scope: :y }
   validates :y, uniqueness: { scope: :x }
+  validates :north, :east, :south, :west, inclusion: [true, false]
 
   has_many :world_items
   has_many :items, through: :world_items
+
+  has_many :world_entities
+  has_many :entities, through: :world_entities
 end

--- a/app/serializers/entity_item_serializer.rb
+++ b/app/serializers/entity_item_serializer.rb
@@ -1,0 +1,5 @@
+class EntityItemSerializer < ActiveModel::Serializer
+  attributes :id
+  has_one :entity
+  has_one :item
+end

--- a/app/serializers/entity_serializer.rb
+++ b/app/serializers/entity_serializer.rb
@@ -1,0 +1,4 @@
+class EntitySerializer < ActiveModel::Serializer
+  attributes :id, :group, :name, :description
+  has_many :items
+end

--- a/app/serializers/world_entity_serializer.rb
+++ b/app/serializers/world_entity_serializer.rb
@@ -1,0 +1,5 @@
+class WorldEntitySerializer < ActiveModel::Serializer
+  attributes :id
+  has_one :worldmap
+  has_one :entities
+end

--- a/app/serializers/worldmap_serializer.rb
+++ b/app/serializers/worldmap_serializer.rb
@@ -1,4 +1,5 @@
 class WorldmapSerializer < ActiveModel::Serializer
   attributes :id, :x, :y, :name, :description, :north, :east, :south, :west
-  has_many :items
+
+  has_many :entities
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,10 @@ Rails.application.routes.draw do
     # resources :world_items
     resources :game_items, only: [:index, :create, :destroy]
     resources :items, only: [:index, :show]
-    # TODO resources :users, only: [:index] # * Included for development/testing purposes -- remember to remove
+    resources :entity_items, only: [:index, :create, :destroy]
+    resources :world_entities, only: [:index, :create, :destroy]
+    resources :entities, only: [:index, :show]
+      # TODO resources :users, only: [:index] # * Included for development/testing purposes -- remember to remove
     # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   
     # Defines the root path route ("/")

--- a/db/migrate/20230123225634_create_entities.rb
+++ b/db/migrate/20230123225634_create_entities.rb
@@ -1,0 +1,11 @@
+class CreateEntities < ActiveRecord::Migration[7.0]
+  def change
+    create_table :entities do |t|
+      t.string :group
+      t.string :name
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230123225743_create_world_entities.rb
+++ b/db/migrate/20230123225743_create_world_entities.rb
@@ -1,0 +1,10 @@
+class CreateWorldEntities < ActiveRecord::Migration[7.0]
+  def change
+    create_table :world_entities do |t|
+      t.references :worldmap, null: false, foreign_key: true
+      t.references :entity, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230123225820_create_entity_items.rb
+++ b/db/migrate/20230123225820_create_entity_items.rb
@@ -1,0 +1,10 @@
+class CreateEntityItems < ActiveRecord::Migration[7.0]
+  def change
+    create_table :entity_items do |t|
+      t.references :entity, null: false, foreign_key: true
+      t.references :item, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,27 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_20_182808) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_23_225820) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
+
+  create_table "entities", force: :cascade do |t|
+    t.string "group"
+    t.string "name"
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "entity_items", force: :cascade do |t|
+    t.bigint "entity_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["entity_id"], name: "index_entity_items_on_entity_id"
+    t.index ["item_id"], name: "index_entity_items_on_item_id"
+  end
 
   create_table "game_items", force: :cascade do |t|
     t.bigint "gamesave_id", null: false
@@ -47,6 +64,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_20_182808) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "world_entities", force: :cascade do |t|
+    t.bigint "worldmap_id", null: false
+    t.bigint "entity_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["entity_id"], name: "index_world_entities_on_entity_id"
+    t.index ["worldmap_id"], name: "index_world_entities_on_worldmap_id"
+  end
+
   create_table "world_items", force: :cascade do |t|
     t.bigint "worldmap_id", null: false
     t.bigint "item_id", null: false
@@ -69,9 +95,13 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_20_182808) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "entity_items", "entities"
+  add_foreign_key "entity_items", "items"
   add_foreign_key "game_items", "gamesaves"
   add_foreign_key "game_items", "items"
   add_foreign_key "gamesaves", "users"
+  add_foreign_key "world_entities", "entities"
+  add_foreign_key "world_entities", "worldmaps"
   add_foreign_key "world_items", "items"
   add_foreign_key "world_items", "worldmaps"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,8 +9,8 @@
 puts "🌱🌱 Seeding started... 🌱🌱"
 
 puts "🧍‍♂️🧍‍♀️ Creating Users... 🧍‍♂️🧍‍♀️"
-u1 = User.create!(username:"Injustice", password:"password")
-u2 = User.create!(username:"Tester", password:"password")
+u1 = User.create!(username:"Test0", password:"password")
+u2 = User.create!(username:"Test1", password:"password")
 
 puts "💾 Creating Gamesaves... 💾"
 g1 = u1.gamesaves.create!()
@@ -26,9 +26,13 @@ m6 = Worldmap.create!(x:-2, y:1, name: "Large Clearing", description: "The sun i
 m7 = Worldmap.create!(x:0, y:-1, name: "South of the Starting Area", description: "A big, white, empty space. Something's wrong. You feel like you shouldn't be here. Perhaps it's best we go back...", north: true, east: false, south: false, west: false)
 
 puts "Generating Items..."
-i1 = m4.items.create!(name: "Fishing Rod", description: "A run-of-the-mill fishing rod")
-i2 = m3.items.create!(name: "Stone Sword", description: "The sword you pulled from the stone sculpture. It has no edge, but it somehow feels sturdy and balanced enough to wield, anyway.")
-i3 = m3.items.create!(name: "Magical Sword", description: "Stone Sword, no longer! An energy emenates from the blade that you can almost see? Nah. Must be your eyes playing tricks.")
+i1 = Item.create!(name: "Fishing Rod", description: "A run-of-the-mill fishing rod")
+i2 = Item.create!(name: "Stone Sword", description: "The sword you pulled from the stone sculpture. It has no edge, but it somehow feels sturdy and balanced enough to wield, anyway.")
+i3 = Item.create!(name: "Magical Sword", description: "Stone Sword, no longer! An energy emenates from the blade that you can almost see? Nah. Must be your eyes playing tricks.")
+
+puts "Generating Entities..."
+e1 = m4.entities.create!(group: "container", name: "Chest", description: "A plain chest. I wonder what's inside?", items: [i1])
+e2 = m3.entities.create!(group: "sculpture", name: "Sculpture of Sword in Stone", description: "It appears to be a stone replica of a plain sword in a hunk of stone. But, like... why?", items: [i2, i3])
 
 # * Worldmap keys/template
 # x:,y:,name:,description:,north:,east:,south:,west:


### PR DESCRIPTION
**Back-End (API)**
- Generated resources for `entities`, `world_entities`, and `entity_items`
  - Specified appropriate `routes` and wrote corresponding `controller`s with strong params
  - Adjusted `serializers` as needed
- Added/adjusted presence and inclusion validations to include every column of `worldmap`, `user`, `gamesave`, and `item` tables to models
- `game_items_controller`
  - Updated `pos_params` (possession) to `item_params`
- `worldmaps_controller`
  - Added inclusion of `entities.items` to `index` and `show`
- `user`
  - Removed unused/commented code
- `worldmap_serializer`
  - Added `entities` and removed `items` associations
- `seeds.rb`
  - Disassociated `items` from `worldmaps`
  - Added `entities` with `items`
  - Changed test `user`names

**Front-End (Client)**
`Game.js`
- Replaced `gridItems` variable (deprecated) with `chestItems`
- Wrote new `gridItems` variable for `Loot` command chain and handler
- `cmdOpenChest`
  - Updated `gridItems` references to `chestItems`
  - Adjusted `unlootedItems` filter condition to work more consistently Instead of evaluating playerItems for mismatched item ids, we now evaluate for absence of matching id's
    - Updated comment accordingly for assistance in reading this chain in a clear and concise way
  - Removed TODO comments, as they've been resolved (yay!)
  - Bugfix: Using this command on maps with no `container` `entities` generates a breaking console error
    - Added `optional chaining` operator (`?.`) to `if` statement condition
    - Moved variable assignments into `if` statement
- `cmdOpenChest`
  - Bugfix: Using this command on maps with no `items` generates a breaking console error - Added `?.` operator to `chestItems.length`
- `handleMove`
  - Commented out `newGameState` validation with TODO to reevaluate for clutter
- `handleLoot`
  - Added `?.` operator to Prompts
  - Bugfix: Conditional ternary was not working correctly (`targetItem` was returning false but truthy codeblock ran anyway)
    - Converted to `if/else` statement and separated `targetItem` into guard clause
  - Added inverted logic to `targetItem` for greater flexibility in player input structure
- `handleInputSubmit`
  - Bugfix: Console error when attempting to use take or loot keywords with a query containing multiple words - Added join to `cmdLoot` call argument
- `handleOutput`
  - Added logic to clean up function calls - if `output` is an object and not an array, wrap `output` with array
  - Removed array brackets from calls to this function where unnecessary